### PR TITLE
Fix textView size in iOS13

### DIFF
--- a/TwitterKit/TwitterKit/TwitterShareExtensionUI/Private/Composer/TWTRSETweetTextViewContainer.m
+++ b/TwitterKit/TwitterKit/TwitterShareExtensionUI/Private/Composer/TWTRSETweetTextViewContainer.m
@@ -111,6 +111,9 @@ static const UIEdgeInsets kComposeTextViewTextContainerInsets = {.top = 8, .left
         _placeholderLabel.translatesAutoresizingMaskIntoConstraints = NO;
         _characterCounterLabel.translatesAutoresizingMaskIntoConstraints = NO;
 
+        if (@available(iOS 13.0, *)) {
+            [self _tseui_updateLineCount];
+        }
         [self setNeedsUpdateConstraints];
     }
 


### PR DESCRIPTION
## Problem

Twitter share view is too small in iOS13.

<img src='https://user-images.githubusercontent.com/1109143/66979123-5bd04c00-f0e7-11e9-82b7-dc8905b1f493.png' width=320>


## Solution

In iOS 13, `TWTRSETweetTextViewContainer.m` does not update line count when initialization, the text view's height always been `0`.
So if init the line count when initialization problem should be resolved.
